### PR TITLE
Adding option to show hidden ssid networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   - [iwconfig.status(callback)](#iwconfigstatuscallback) - status of all wireless network interfaces
   - [iwconfig.status(interface, callback)](#iwconfigstatusinterface-callback) - status of a wireless network interface
 - [iwlist](#iwlist) - query wireless network interfaces
-  - [iwlist.scan(interface, callback)](#iwlistscaninterface-callback) - scan for wireless networks
+  - [iwlist.scan(options, callback)](#iwlistscaninterface-callback) - scan for wireless networks
 - [udhcpc](#udhcpc) - configure a dhcp client
   - [udhcpc.enable(options, callback)](#udhcpcenableoptions-callback) - start a dhcp client
   - [udhcpc.disable(interface, callback)](#udhcpcdisableinterface-callback) - stop a dhcp client
@@ -163,7 +163,7 @@ var options = {
 };
 
 ifconfig.up(options, function(err) {
-  // the interface is up 
+  // the interface is up
 });
 ```
 
@@ -245,6 +245,10 @@ iwlist.scan('wlan0', function(err, networks) {
   console.log(networks);
 });
 
+iwlist.scan({ iface : 'wlan0', show_hidden : true }, function(err, networks) {
+  console.log(networks);
+});
+
 // =>
 [
   {
@@ -286,6 +290,58 @@ iwlist.scan('wlan0', function(err, networks) {
     security: 'open',
     quality: 32,
     signal: 71
+  }
+]
+
+[
+  {
+    address: '00:0b:81:ab:14:22',
+    ssid: 'BlueberryPi',
+    mode: 'master',
+    frequency: 2.437,
+    channel: 6,
+    security: 'wpa',
+    quality: 48,
+    signal: 87
+  },
+  {
+    address: '00:0b:81:95:12:21',
+    ssid: 'RaspberryPi',
+    mode: 'master',
+    frequency: 2.437,
+    channel: 6,
+    security: 'wpa2',
+    quality: 58,
+    signal: 83
+  },
+  {
+    address: '00:0b:81:cd:f2:04',
+    ssid: 'BlackberryPi',
+    mode: 'master',
+    frequency: 2.437,
+    channel: 6,
+    security: 'wep',
+    quality: 48,
+    signal: 80
+  },
+  {
+    address: '00:0b:81:fd:42:14',
+    ssid: 'CranberryPi',
+    mode: 'master',
+    frequency: 2.437,
+    channel: 6,
+    security: 'open',
+    quality: 32,
+    signal: 71
+  },
+  {
+    address: '2c:c5:d3:02:ae:4c',
+    channel: 100,
+    frequency: 5.5,
+    mode: 'master',
+    quality: 66,
+    signal: -44,
+    security: 'wpa2'
   }
 ]
 ```

--- a/iwlist.js
+++ b/iwlist.js
@@ -294,5 +294,11 @@ function scan(options, callback) {
     show_hidden = options.show_hidden || false;
   }
 
-  this.exec('iwlist ' + interface + ' scan', parse_scan(show_hidden, callback));
+  var extra_params = '';
+
+  if (options.ssid) {
+    extra_params = ' essid ' + options.ssid;
+  }
+
+  this.exec('iwlist ' + interface + ' scan' + extra_params, parse_scan(show_hidden, callback));
 }

--- a/test/iwlist.js
+++ b/test/iwlist.js
@@ -71,8 +71,23 @@ var IWLIST_SCAN_LINUX = [
 '          Bit Rates:144 Mb/s',
 '          IE: Unknown: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
 '          Quality=32/100  Signal level=71/100',
-'Cell 05 - Address: 00:0B:81:ED:E2:44',
-'          ESSID:""'
+'Cell 05 - Address: 2C:C5:D3:02:AE:4C',
+'          Channel:100',
+'          Frequency:5.5 GHz (Channel 100)',
+'          Quality=65/70  Signal level=-45 dBm',
+'          Encryption key:on',
+'          ESSID:""',
+'          Bit Rates:24 Mb/s; 36 Mb/s; 48 Mb/s; 54 Mb/s',
+'          Mode:Master',
+'          Extra:tsf=0000003d2a54d03b',
+'          Extra: Last beacon: 3360ms ago',
+'          IE: Unknown: DD180050F20201018E0003A4000027A4000042435E0062322F00',
+'          IE: Unknown: 2D1AAD091BF8FE000000000000000000001000000000000000000000',
+'          IE: Unknown: 3D1664000000000000000000000000000000000000000000',
+'          IE: IEEE 802.11i/WPA2 Version 1',
+'              Group Cipher : CCMP',
+'              Pairwise Ciphers (1) : CCMP',
+'              Authentication Suites (1) : PSK'
 ].join('\n');
 
 describe('iwlist', function() {
@@ -126,6 +141,75 @@ describe('iwlist', function() {
             signal: 71
           }
         ]);
+
+        done();
+      });
+    })
+
+    it('should scan the specified interface and show hidden ssid networks', function(done) {
+      iwlist.exec = function(command, callback) {
+        should(command).eql('iwlist wlan0 scan');
+        callback(null, IWLIST_SCAN_LINUX, '');
+      };
+
+      var options = {
+        iface: 'wlan0',
+        show_hidden: true
+      };
+
+      iwlist.scan(options, function(err, status) {
+        should(status).eql(
+          [
+          {
+            address: '00:0b:81:ab:14:22',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 48,
+            signal: 87,
+            ssid: 'BlueberryPi',
+            security: 'wpa'
+          },
+          {
+            address: '00:0b:81:95:12:21',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 58,
+            signal: 83,
+            ssid: 'RaspberryPi',
+            security: 'wpa2'
+          },
+          {
+            address: '00:0b:81:cd:f2:04',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 48,
+            signal: 80,
+            ssid: 'BlackberryPi',
+            security: 'wep'
+          },
+          {
+            address: '00:0b:81:fd:42:14',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 32,
+            signal: 71,
+            ssid: 'CranberryPi',
+            security: 'open'
+          },
+          {
+            address: '2c:c5:d3:02:ae:4c',
+            channel: 100,
+            frequency: 5.5,
+            mode: 'master',
+            quality: 65,
+            signal: -45,
+            security: 'wpa2'
+          }
+          ]);
 
         done();
       });

--- a/test/iwlist.js
+++ b/test/iwlist.js
@@ -90,6 +90,72 @@ var IWLIST_SCAN_LINUX = [
 '              Authentication Suites (1) : PSK'
 ].join('\n');
 
+var IWLIST_SCAN_LINUX_ACTIVE_SCAN = [
+'Cell 01 - Address: 00:0B:81:95:12:21',
+'          ESSID:"RaspberryPi"',
+'          Protocol:IEEE 802.11bgn',
+'          Mode:Master',
+'          Frequency:2.437 GHz (Channel 6)',
+'          Encryption key:on',
+'          Bit Rates:144 Mb/s',
+'          Extra:rsn_ie=00000000000000000000000000000000000000000000',
+'          IE: IEEE 802.11i/WPA2 Version 1',
+'              Group Cipher : CCMP',
+'              Pairwise Ciphers (1) : CCMP',
+'              Authentication Suites (1) : PSK',
+'          IE: Unknown: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+'          Quality=58/100  Signal level=83/100',
+'Cell 02 - Address: 00:0B:81:AB:14:22',
+'          ESSID:"BlueberryPi"',
+'          Protocol:IEEE 802.11bgn',
+'          Mode:Master',
+'          Frequency:2.437 GHz (Channel 6)',
+'          Encryption key:on',
+'          Bit Rates:144 Mb/s',
+'          IE: WPA Version 1',
+'              Group Cipher : TKIP',
+'              Pairwise Ciphers (2) : CCMP TKIP',
+'              Authentication Suites (1) : PSK',
+'          Extra:rsn_ie=0000000000000000000000000000000000000000000000000000',
+'          Quality=48/100  Signal level=87/100',
+'Cell 03 - Address: 00:0B:81:CD:F2:04',
+'          ESSID:"BlackberryPi"',
+'          Protocol:IEEE 802.11bgn',
+'          Mode:Master',
+'          Frequency:2.437 GHz (Channel 6)',
+'          Encryption key:on',
+'          Bit Rates:144 Mb/s',
+'          IE: Unknown: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+'          Extra:rsn_ie=0000000000000000000000000000000000000000000000000000',
+'          Quality=48/100  Signal level=80/100',
+'Cell 04 - Address: 00:0B:81:FD:42:14',
+'          ESSID:"CranberryPi"',
+'          Protocol:IEEE 802.11bgn',
+'          Mode:Master',
+'          Frequency:2.437 GHz (Channel 6)',
+'          Encryption key:off',
+'          Bit Rates:144 Mb/s',
+'          IE: Unknown: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+'          Quality=32/100  Signal level=71/100',
+'Cell 05 - Address: 2C:C5:D3:02:AE:4C',
+'          Channel:100',
+'          Frequency:5.5 GHz (Channel 100)',
+'          Quality=65/70  Signal level=-45 dBm',
+'          Encryption key:on',
+'          ESSID:"hidden-ssid"',
+'          Bit Rates:24 Mb/s; 36 Mb/s; 48 Mb/s; 54 Mb/s',
+'          Mode:Master',
+'          Extra:tsf=0000003d2a54d03b',
+'          Extra: Last beacon: 3360ms ago',
+'          IE: Unknown: DD180050F20201018E0003A4000027A4000042435E0062322F00',
+'          IE: Unknown: 2D1AAD091BF8FE000000000000000000001000000000000000000000',
+'          IE: Unknown: 3D1664000000000000000000000000000000000000000000',
+'          IE: IEEE 802.11i/WPA2 Version 1',
+'              Group Cipher : CCMP',
+'              Pairwise Ciphers (1) : CCMP',
+'              Authentication Suites (1) : PSK'
+].join('\n');
+
 describe('iwlist', function() {
   describe('iwlist.scan(interface, callback)', function() {
     it('should scan the specified interface', function(done) {
@@ -207,6 +273,77 @@ describe('iwlist', function() {
             mode: 'master',
             quality: 65,
             signal: -45,
+            security: 'wpa2'
+          }
+          ]);
+
+        done();
+      });
+    })
+
+    it('should scan the specified interface looking for hidden ssid', function(done) {
+      iwlist.exec = function(command, callback) {
+        should(command).eql('iwlist wlan0 scan essid hidden-ssid');
+        callback(null, IWLIST_SCAN_LINUX_ACTIVE_SCAN, '');
+      };
+
+      var options = {
+        iface: 'wlan0',
+        show_hidden: false,
+        ssid: 'hidden-ssid'
+      };
+
+      iwlist.scan(options, function(err, status) {
+        should(status).eql(
+          [
+          {
+            address: '00:0b:81:ab:14:22',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 48,
+            signal: 87,
+            ssid: 'BlueberryPi',
+            security: 'wpa'
+          },
+          {
+            address: '00:0b:81:95:12:21',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 58,
+            signal: 83,
+            ssid: 'RaspberryPi',
+            security: 'wpa2'
+          },
+          {
+            address: '00:0b:81:cd:f2:04',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 48,
+            signal: 80,
+            ssid: 'BlackberryPi',
+            security: 'wep'
+          },
+          {
+            address: '00:0b:81:fd:42:14',
+            channel: 6,
+            frequency: 2.437,
+            mode: 'master',
+            quality: 32,
+            signal: 71,
+            ssid: 'CranberryPi',
+            security: 'open'
+          },
+          {
+            address: '2c:c5:d3:02:ae:4c',
+            channel: 100,
+            frequency: 5.5,
+            mode: 'master',
+            quality: 65,
+            signal: -45,
+            ssid: 'hidden-ssid',
             security: 'wpa2'
           }
           ]);

--- a/test/wpa_cli.js
+++ b/test/wpa_cli.js
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2015 Christopher M. Baker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+var should = require('should');
+var wpa_cli = require('../wpa_cli');
+
+var WPA_CLI_STATUS_COMPLETED = [
+    'bssid=2c:f5:d3:02:ea:d9',
+    'freq=2412',
+    'ssid=Fake-Wifi',
+    'id=0',
+    'mode=station',
+    'pairwise_cipher=CCMP',
+    'group_cipher=CCMP',
+    'key_mgmt=WPA2-PSK',
+    'wpa_state=COMPLETED',
+    'ip_address=10.34.141.168',
+    'p2p_device_address=e4:28:9c:a8:53:72',
+    'address=e4:28:9c:a8:53:72',
+    'uuid=e1cda789-8c88-53e8-ffff-31c304580c1e'
+].join('\n');
+
+var WPA_CLI_STATUS_4WAY_HANDSHAKE = [
+    'bssid=2c:f5:d3:02:ea:d9',
+    'freq=2412',
+    'ssid=Fake-Wifi',
+    'id=0',
+    'mode=station',
+    'pairwise_cipher=CCMP',
+    'group_cipher=CCMP',
+    'key_mgmt=WPA2-PSK',
+    'wpa_state=4WAY_HANDSHAKE',
+    'ip_address=10.34.141.168',
+    'p2p_device_address=e4:28:9c:a8:53:72',
+    'address=e4:28:9c:a8:53:72',
+    'uuid=e1cda789-8c88-53e8-ffff-31c304580c1e'
+].join('\n');
+
+var WPA_CLI_STATUS_SCANNING = [
+    'wpa_state=SCANNING',
+    'ip_address=10.34.141.168',
+    'p2p_device_address=e4:28:9c:a8:53:72',
+    'address=e4:28:9c:a8:53:72',
+    'uuid=e1cda789-8c88-53e8-ffff-31c304580c1e'
+].join('\n');
+
+var WPA_CLI_COMMAND_OK = 'OK\n';
+var WPA_CLI_COMMAND_FAIL = 'FAIL\n';
+
+describe('wpa_cli', function() {
+    describe('wpa_cli.status(iface, callback)', function() {
+        before(function() {
+            this.OUTPUT = '';
+            var self = this;
+
+            wpa_cli.exec = function(command, callback) {
+                should(command).eql('wpa_cli -i wlan0 status');
+                callback(null, self.OUTPUT);
+            };
+        });
+
+        it('status COMPLETED', function(done) {
+            this.OUTPUT = WPA_CLI_STATUS_COMPLETED;
+            wpa_cli.status('wlan0', function(err, status) {
+                should(status).eql({
+                    bssid: '2c:f5:d3:02:ea:d9',
+                    frequency: 2412,
+                    mode: 'station',
+                    key_mgmt: 'wpa2-psk',
+                    ssid: 'Fake-Wifi',
+                    pairwise_cipher: 'CCMP',
+                    group_cipher: 'CCMP',
+                    p2p_device_address: 'e4:28:9c:a8:53:72',
+                    wpa_state: 'COMPLETED',
+                    ip: '10.34.141.168',
+                    mac: 'e4:28:9c:a8:53:72',
+                    uuid: 'e1cda789-8c88-53e8-ffff-31c304580c1e',
+                    id: 0
+                });
+
+                done();
+            });
+        });
+
+        it('status 4WAY_HANDSHAKE', function(done) {
+            this.OUTPUT = WPA_CLI_STATUS_4WAY_HANDSHAKE;
+            wpa_cli.status('wlan0', function(err, status) {
+                should(status).eql({
+                    bssid: '2c:f5:d3:02:ea:d9',
+                    frequency: 2412,
+                    mode: 'station',
+                    key_mgmt: 'wpa2-psk',
+                    ssid: 'Fake-Wifi',
+                    pairwise_cipher: 'CCMP',
+                    group_cipher: 'CCMP',
+                    p2p_device_address: 'e4:28:9c:a8:53:72',
+                    wpa_state: '4WAY_HANDSHAKE',
+                    ip: '10.34.141.168',
+                    mac: 'e4:28:9c:a8:53:72',
+                    uuid: 'e1cda789-8c88-53e8-ffff-31c304580c1e',
+                    id: 0
+                });
+
+                done();
+            });
+        });
+
+        it('status SCANNING', function(done) {
+            this.OUTPUT = WPA_CLI_STATUS_SCANNING;
+            wpa_cli.status('wlan0', function(err, status) {
+                should(status).eql({
+                    p2p_device_address: 'e4:28:9c:a8:53:72',
+                    wpa_state: 'SCANNING',
+                    ip: '10.34.141.168',
+                    mac: 'e4:28:9c:a8:53:72',
+                    uuid: 'e1cda789-8c88-53e8-ffff-31c304580c1e' });
+            });
+
+            done();
+        });
+
+        it('should handle errors', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                callback('error');
+            };
+
+            wpa_cli.status('wlan0', function(err, status) {
+                should(err).eql('error');
+                done();
+            });
+        });
+    });
+
+    describe('wpa_cli.bssid(iface, ap, ssid, callback)', function(){
+        it('OK result', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                should(command).eql('wpa_cli -i wlan0 bssid Fake-Wifi 2c:f5:d3:02:ea:89');
+                callback(null, WPA_CLI_COMMAND_OK);
+            };
+
+            wpa_cli.bssid('wlan0', '2c:f5:d3:02:ea:89', 'Fake-Wifi', function(err, status) {
+                should(status).eql({
+                    result: 'OK'
+                });
+
+                done();
+            });
+        });
+
+        it('FAIL result', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                should(command).eql('wpa_cli -i wlan0 bssid 2c:f5:d3:02:ea:89 Fake-Wifi');
+                callback(null, WPA_CLI_COMMAND_FAIL);
+            };
+
+            wpa_cli.bssid('wlan0', 'Fake-Wifi', '2c:f5:d3:02:ea:89', function(err, status) {
+                should(err.message).eql('FAIL');
+                done();
+            });
+        });
+
+        it('Handle errors', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                callback('error');
+            };
+
+            wpa_cli.bssid('wlan0', '2c:f5:d3:02:ea:89', 'Fake-Wifi', function(err, status) {
+                should(err).eql('error');
+                done();
+            });
+        });
+    });
+
+    describe('wpa_cli.reassociate(iface, callback)', function(){
+        it('OK result', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                should(command).eql('wpa_cli -i wlan0 reassociate');
+                callback(null, WPA_CLI_COMMAND_OK);
+            };
+
+            wpa_cli.reassociate('wlan0', function(err, status) {
+                should(status).eql({
+                    result: 'OK'
+                });
+
+                done();
+            });
+        });
+
+        it('FAIL result', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                should(command).eql('wpa_cli -i wlan0 reassociate');
+                callback(null, WPA_CLI_COMMAND_FAIL);
+            };
+
+            wpa_cli.reassociate('wlan0', function(err, status) {
+                should(err.message).eql('FAIL');
+                done();
+            });
+        });
+
+        it('should handle errors', function(done) {
+            wpa_cli.exec = function(command, callback) {
+                callback('error');
+            };
+
+            wpa_cli.reassociate('wlan0', function(err, status) {
+                should(err).eql('error');
+                done();
+            });
+        });
+    });
+});

--- a/test/wpa_supplicant.js
+++ b/test/wpa_supplicant.js
@@ -29,7 +29,7 @@ describe('wpa_supplicant', function() {
     it('should stop the daemons', function(done) {
       wpa_supplicant.exec = function(command, callback) {
         should(command).eql(
-          'kill `pgrep -f "^wpa_supplicant -i wlan0"` || true');
+          'kill `pgrep -f "wpa_supplicant .* -i wlan0"` || true');
 
         callback(null, '', '');
       };
@@ -89,6 +89,45 @@ describe('wpa_supplicant', function() {
       };
 
       wpa_supplicant.enable(options, function(err) {
+        should(err).eql('error');
+        done();
+      });
+    })
+  })
+
+  describe('wpa_supplicant.manual(options, callback)', function() {
+    it('should start the daemon', function(done) {
+      wpa_supplicant.exec = function(command, callback) {
+        should(command).eql([
+          'wpa_supplicant -s -B -P /run/wpa_supplicant/wlan0.pid',
+          '-i wlan0 -D nl80211,wext -C /run/wpa_supplicant'
+          ].join(' '));
+
+        callback(null, '', '');
+      };
+
+      var options = {
+        interface: 'wlan0',
+        drivers: [ 'nl80211', 'wext' ]
+      };
+
+      wpa_supplicant.manual(options, function(err) {
+        should(err).not.be.ok;
+        done();
+      });
+    })
+
+    it('should handle errors', function(done) {
+      wpa_supplicant.exec = function(command, callback) {
+        callback('error');
+      };
+
+      var options = {
+        interface: 'wlan0',
+        drivers: [ 'nl80211', 'wext' ]
+      };
+
+      wpa_supplicant.manual(options, function(err) {
         should(err).eql('error');
         done();
       });

--- a/wpa_cli.js
+++ b/wpa_cli.js
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2015 Christopher M. Baker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+var child_process = require('child_process');
+
+/**
+ * The **wpa_cli** command is used to configure wpa network interfaces.
+ *
+ * @private
+ * @category wpa_cli
+ *
+ */
+var wpa_cli = module.exports = {
+    exec: child_process.exec,
+    status: status,
+    bssid: bssid,
+    reassociate: reassociate,
+    set: set,
+    add_network: add_network,
+    set_network: set_network,
+    enable_network: enable_network,
+    disable_network: disable_network,
+    remove_network: remove_network
+};
+
+/**
+ * Parses the status for a wpa network interface.
+ *
+ * @private
+ * @static
+ * @category wpa_cli
+ * @param {string} block The section of stdout for the interface.
+ * @returns {object} The parsed wpa status.
+ *
+ */
+function parse_status_block(block) {
+    var match;
+
+    var parsed = {};
+    if ((match = block.match(/bssid=([A-Fa-f0-9:]{17})/))) {
+        parsed.bssid = match[1].toLowerCase();
+    }
+
+    if ((match = block.match(/freq=([0-9]+)/))) {
+        parsed.frequency = parseInt(match[1], 10);
+    }
+
+    if ((match = block.match(/mode=([^\s]+)/))) {
+        parsed.mode = match[1];
+    }
+
+    if ((match = block.match(/key_mgmt=([^\s]+)/))) {
+        parsed.key_mgmt = match[1].toLowerCase();
+    }
+
+    if ((match = block.match(/[^b]ssid=([^\n]+)/))) {
+        parsed.ssid = match[1];
+    }
+
+    if ((match = block.match(/[^b]pairwise_cipher=([^\n]+)/))) {
+        parsed.pairwise_cipher = match[1];
+    }
+
+    if ((match = block.match(/[^b]group_cipher=([^\n]+)/))) {
+        parsed.group_cipher = match[1];
+    }
+
+    if ((match =  block.match(/p2p_device_address=([A-Fa-f0-9:]{17})/))) {
+        parsed.p2p_device_address = match[1];
+    }
+
+    if ((match = block.match(/wpa_state=([^\s]+)/))) {
+        parsed.wpa_state = match[1];
+    }
+
+    if ((match = block.match(/ip_address=([^\n]+)/))) {
+        parsed.ip = match[1];
+    }
+
+    if ((match = block.match(/[^_]address=([A-Fa-f0-9:]{17})/))) {
+        parsed.mac = match[1].toLowerCase();
+    }
+
+    if ((match = block.match(/uuid=([^\n]+)/))) {
+        parsed.uuid = match[1];
+    }
+
+    if ((match = block.match(/[^s]id=([0-9]+)/))) {
+        parsed.id = parseInt(match[1], 10);
+    }
+
+    return parsed;
+}
+
+/**
+ * Parses the result for a wpa command over an interface.
+ *
+ * @private
+ * @static
+ * @category wpa_cli
+ * @param {string} block The section of stdout for the command.
+ * @returns {object} The parsed wpa command result.
+ *
+ */
+function parse_command_block(block) {
+    var match;
+
+    var parsed = {
+        result: block.match(/^([^\s]+)/)[1]
+    };
+
+    return parsed;
+}
+
+/**
+ * Parses the status for a wpa wireless network interface.
+ *
+ * @private
+ * @static
+ * @category wpa_cli
+ * @param {function} callback The callback function.
+ *
+ */
+function parse_status_interface(callback) {
+    return function(error, stdout, stderr) {
+        if (error) {
+            callback(error);
+        } else {
+            callback(error, parse_status_block(stdout.trim()));
+        }
+    };
+}
+
+/**
+ * Parses the result for a wpa command over an interface.
+ *
+ * @private
+ * @static
+ * @category wpa_cli
+ * @param {function} callback The callback function.
+ *
+ */
+function parse_command_interface(callback) {
+    return function(error, stdout, stderr) {
+        if (error) {
+            callback(error);
+        } else {
+            var output = parse_command_block(stdout.trim());
+            if (output.result === 'FAIL') {
+                callback(new Error(output.result));
+            } else {
+                callback(error, parse_command_block(stdout.trim()));
+            }
+        }
+    };
+}
+
+
+/**
+ * Parses the status for wpa network interface.
+ *
+ * @private
+ * @static
+ * @category wpa
+ * @param {string} [interface] The wireless network interface.
+ * @param {function} callback The callback function.
+ * @example
+ *
+ * var wpa_cli = require('wireless-tools/wpa_cli');
+ *
+ * wpa_cli.status('wlan0', function(err, status) {
+ *     console.dir(status);
+ *     wpa_cli.bssid('wlan0', '2c:f5:d3:02:ea:dd', 'Fake-Wifi', function(err, data){
+ *         console.dir(data);
+ *         wpa_cli.bssid('wlan0', 'Fake-Wifi', '2c:f5:d3:02:ea:dd', function(err, data){
+ *             if (err) {
+ *                 console.dir(err);
+ *                 wpa_cli.reassociate('wlan0', function(err, data) {
+ *                     console.dir(data);
+ *                 });
+ *              }
+ *          });
+ *     });
+ * });
+ *
+ *
+ *
+ * // =>
+ * {
+ *     bssid: '2c:f5:d3:02:ea:d9',
+ *     frequency: 2412,
+ *     mode: 'station',
+ *     key_mgmt: 'wpa2-psk',
+ *     ssid: 'Fake-Wifi',
+ *     pairwise_cipher: 'CCMP',
+ *     group_cipher: 'CCMP',
+ *     p2p_device_address: 'e4:28:9c:a8:53:72',
+ *     wpa_state: 'COMPLETED',
+ *     ip: '10.34.141.168',
+ *     mac: 'e4:28:9c:a8:53:72',
+ *     uuid: 'e1cda789-8c88-53e8-ffff-31c304580c1e',
+ *     id: 0
+ * }
+ *
+ * OK
+ *
+ * FAIL
+ *
+ * OK
+ *
+ */
+function status(interface, callback) {
+    var command = [ 'wpa_cli -i', interface, 'status'].join(' ');
+    return this.exec(command, parse_status_interface(callback));
+}
+
+function bssid(interface, ap, ssid, callback) {
+    var command = ['wpa_cli -i', interface, 'bssid', ssid, ap].join(' ');
+    return this.exec(command, parse_command_interface(callback));
+}
+
+function reassociate(interface, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'reassociate'].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}
+
+/* others commands not tested
+    //ap_scan 1
+    // set_network 0 0 scan_ssid 1
+
+
+    // set: set,
+    // add_network: add_network,
+    // set_network: set_network,
+    // enable_network: enable_network
+*/
+
+function set(interface, variable, value, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'set',
+                 variable,
+                 value ].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}
+
+function add_network(interface, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'add_network' ].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}
+
+function set_network(interface, id, variable, value, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'set_network',
+                 id,
+                 variable,
+                 value ].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}
+
+function enable_network(interface, id, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'enable_network',
+                 id ].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}
+
+function disable_network(interface, id, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'disable_network',
+                 id ].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}
+
+function remove_network(interface, id, callback) {
+    var command = ['wpa_cli -i',
+                 interface,
+                 'remove_network',
+                 id ].join(' ');
+
+    return this.exec(command, parse_command_interface(callback));
+}


### PR DESCRIPTION
Adding option to iwlist to not filter hidden ssid networks
If calling iwlist with an object (instead of just the interface) like
{
  iface : 'wlan0',
  show_hidden : true
}

It won't filter networks (will show also hidden ssid networks)