### PR TITLE
Prevent raised error if running iwconfig on a machine with no WLAN adapters

### DIFF
--- a/iwconfig.js
+++ b/iwconfig.js
@@ -49,7 +49,7 @@ function parse_status_block(block) {
   var match;
 
   // Skip out of the block is invalid
-  // if (!block) return;
+  if (!block) return;
 
   var parsed = {
     interface: block.match(/^([^\s]+)/)[1]

--- a/iwconfig.js
+++ b/iwconfig.js
@@ -48,6 +48,9 @@ var iwconfig = module.exports = {
 function parse_status_block(block) {
   var match;
 
+  // Skip out of the block is invalid
+  // if (!block) return;
+
   var parsed = {
     interface: block.match(/^([^\s]+)/)[1]
   };
@@ -108,7 +111,7 @@ function parse_status(callback) {
   return function(error, stdout, stderr) {
     if (error) callback(error);
     else callback(error,
-      stdout.trim().split('\n\n').map(parse_status_block));
+      stdout.trim().split('\n\n').map(parse_status_block).filter(function(i) { return !! i }));
   };
 }
 


### PR DESCRIPTION
There is a nasty raised exception when trying to parse an iwconfig return block if the machine actually has no WLAN adapters at all.

It seems `parse_status_block()` gets handed a null string which then gets parsed as if the regular expressions will always succeed rather than adding an extra check for validity.