### PR TITLE
Prevent global namespace leak, fix iwconfig param check

### DIFF
--- a/iwconfig.js
+++ b/iwconfig.js
@@ -172,11 +172,11 @@ function parse_status_interface(callback) {
  *
  */
 function status(interface, callback) {
-  if (callback) {
+  if (interface) {
     return this.exec('iwconfig ' + interface,
       parse_status_interface(callback));  
   }
   else {
-    return this.exec('iwconfig', parse_status(interface));  
+    return this.exec('iwconfig', parse_status(callback));  
   }
 }

--- a/iwlist.js
+++ b/iwlist.js
@@ -77,6 +77,7 @@ function by_signal(a, b) {
  */
 function parse_cell(cell) {
   var parsed = { };
+  var match;
 
   if ((match = cell.match(/Address\s*[:|=]\s*([A-Fa-f0-9:]{17})/))) {
     parsed.address = match[1].toLowerCase();


### PR DESCRIPTION
### Prevent global namespace leak:
'match' was leaking into the global namespace from iwlist.js

### Fix optional interface arg in iwconfig.js:
The `if` in `iwconfig.status()` was checking the wrong argument.