### PR TITLE
Prevent global namespace leak in iwlist.js

### DIFF
--- a/iwlist.js
+++ b/iwlist.js
@@ -77,6 +77,7 @@ function by_signal(a, b) {
  */
 function parse_cell(cell) {
   var parsed = { };
+  var match;
 
   if ((match = cell.match(/Address\s*[:|=]\s*([A-Fa-f0-9:]{17})/))) {
     parsed.address = match[1].toLowerCase();


### PR DESCRIPTION
`match` was leaking into the global namespace from iwlist's `parse_cell()`