### PR TITLE
Fixes matches for Fedora / Kali-like ifconfig outputs

### DIFF
--- a/ifconfig.js
+++ b/ifconfig.js
@@ -58,23 +58,23 @@ function parse_status_block(block) {
     parsed.link = match[1].toLowerCase();
   }
 
-  if ((match = block.match(/HWaddr\s+([^\s]+)/))) {
+  if ((match = block.match(/HWaddr|ether\s+([^\s]+)/))) {
     parsed.address = match[1].toLowerCase();
   }
 
-  if ((match = block.match(/inet6\s+addr:\s*([^\s]+)/))) {
+  if ((match = block.match(/inet6\s?(addr:\s)*([^\s]+)/))) {
     parsed.ipv6_address = match[1];
   }
 
-  if ((match = block.match(/inet\s+addr:\s*([^\s]+)/))) {
+  if ((match = block.match(/inet\s?(addr:\s)*([^\s]+)/))) {
     parsed.ipv4_address = match[1];
   }
 
-  if ((match = block.match(/Bcast:\s*([^\s]+)/))) {
+  if ((match = block.match(/Bcast:|broadcast\s*([^\s]+)/))) {
     parsed.ipv4_broadcast = match[1];
   }
 
-  if ((match = block.match(/Mask:\s*([^\s]+)/))) {
+  if ((match = block.match(/Mask|netmask\s*([^\s]+)/))) {
     parsed.ipv4_subnet_mask = match[1];
   }
 


### PR DESCRIPTION
A few matches don't seem to work nicely on Kali linux, and also looking around the web fedora does the same output style with ifconfig.  This solves it as cleanly as I can for the two "ifconfig flavors" I've seem to come across..  on a side note, the kali / fedora way of doing it also has a ':' after the interface name.  Taking in this pull request would greatly simplify my program lol.  I will work on other aspects of your code as I continue writing my app and find any other inconsistencies... (iwconfig, for example?)