### PR TITLE
connect to open wifi network

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ var wpa_supplicant = require('wireless-tools/wpa_supplicant');
 var options = {
   interface: 'wlan0',
   ssid: 'RaspberryPi',
-  passphrase: 'raspberry',
+  passphrase: 'raspberry', //optional for open networks
   driver: 'wext'
 };
 

--- a/test/wpa_supplicant.js
+++ b/test/wpa_supplicant.js
@@ -95,6 +95,47 @@ describe('wpa_supplicant', function() {
     })
   })
 
+  describe('wpa_supplicant.enable(options, callback)', function() {
+    it('should start the daemon using key_mgmt=NONE', function(done) {
+      wpa_supplicant.exec = function(command, callback) {
+        should(command).eql("printf 'network={ \n\tssid=\"RaspberryPi\"\n\tkey_mgmt=NONE\n}\n'" +
+          ' > wlan0-wpa_supplicant.conf &&' +
+          ' wpa_supplicant -i wlan0 -B -D wext -c wlan0-wpa_supplicant.conf' +
+          ' && rm -f wlan0-wpa_supplicant.conf');
+
+        callback(null, '', '');
+      };
+
+      var options = {
+        interface: 'wlan0',
+        ssid: 'RaspberryPi',
+        driver: 'wext'
+      };
+
+      wpa_supplicant.enable(options, function(err) {
+        should(err).not.be.ok;
+        done();
+      });
+    })
+
+    it('should handle errors', function(done) {
+      wpa_supplicant.exec = function(command, callback) {
+        callback('error');
+      };
+
+      var options = {
+        interface: 'wlan0',
+        ssid: 'RaspberryPi',
+        driver: 'wext'
+      };
+
+      wpa_supplicant.enable(options, function(err) {
+        should(err).eql('error');
+        done();
+      });
+    })
+  })
+
   describe('wpa_supplicant.manual(options, callback)', function() {
     it('should start the daemon', function(done) {
       wpa_supplicant.exec = function(command, callback) {

--- a/test/wpa_supplicant.js
+++ b/test/wpa_supplicant.js
@@ -76,27 +76,7 @@ describe('wpa_supplicant', function() {
       });
     })
 
-    it('should handle errors', function(done) {
-      wpa_supplicant.exec = function(command, callback) {
-        callback('error');
-      };
-
-      var options = {
-        interface: 'wlan0',
-        ssid: 'RaspberryPi',
-        passphrase: 'raspberry',
-        driver: 'wext'
-      };
-
-      wpa_supplicant.enable(options, function(err) {
-        should(err).eql('error');
-        done();
-      });
-    })
-  })
-
-  describe('wpa_supplicant.enable(options, callback)', function() {
-    it('should start the daemon using key_mgmt=NONE', function(done) {
+    it('should start the daemon using open wifi network', function(done) {
       wpa_supplicant.exec = function(command, callback) {
         should(command).eql("printf 'network={ \n\tssid=\"RaspberryPi\"\n\tkey_mgmt=NONE\n}\n'" +
           ' > wlan0-wpa_supplicant.conf &&' +
@@ -126,6 +106,7 @@ describe('wpa_supplicant', function() {
       var options = {
         interface: 'wlan0',
         ssid: 'RaspberryPi',
+        passphrase: 'raspberry',
         driver: 'wext'
       };
 

--- a/wpa_supplicant.js
+++ b/wpa_supplicant.js
@@ -91,9 +91,15 @@ function disable(interface, callback) {
 function enable(options, callback) {
   var file = options.interface + '-wpa_supplicant.conf';
 
-  var command = 'wpa_passphrase "' + options.ssid + '" "' + options.passphrase
-    + '" > ' + file + ' && wpa_supplicant -i ' + options.interface + ' -B -D '
-    + options.driver + ' -c ' + file + ' && rm -f ' + file;
+  if(options.passphrase) {
+    var command = 'wpa_passphrase "' + options.ssid + '" "' + options.passphrase
+      + '" > ' + file + ' && wpa_supplicant -i ' + options.interface + ' -B -D '
+      + options.driver + ' -c ' + file + ' && rm -f ' + file;
+  } else {
+    var command = "printf 'network={ \n" + "\tssid=\""+ options.ssid + "\"\n"
+      + "\tkey_mgmt=NONE\n" + "}\n' > " + file + ' && wpa_supplicant -i '
+      + options.interface + ' -B -D ' + options.driver + ' -c ' + file + ' && rm -f ' + file;
+  }
 
   return this.exec(command, callback);
 }


### PR DESCRIPTION
add support to wpa_supplicant to allow connecting to an open wifi network by not providing a passphrase option. The conf file is created with a `key_mgmt=NONE` setting.

```
var wpa_supplicant = require('wireless-tools/wpa_supplicant');
var options = {
  interface: 'wlan0',
  ssid: 'FreePublicWifi',
  driver: 'wext'
};

wpa_supplicant.enable(options, function(err) {
  // connected to the wireless network
});
```