### PR TITLE
Fix scan result hidden network

### DIFF
--- a/test/wpa_cli.js
+++ b/test/wpa_cli.js
@@ -72,6 +72,12 @@ var WPA_CLI_SCAN_RESULTS = [
     '2c:f5:d3:02:ea:d9	2472	-31	[WPA-PSK-CCMP+TKIP][WPA2-PSK-CCMP+TKIP][ESS]	FakeWifi2'
 ].join('\n');
 
+var WPA_CLI_SCAN_RESULTS_HIDDEN = [
+    'bssid / frequency / signal level / flags / ssid',
+    '2c:f5:d3:02:ea:11\t2472\t-31\t[ESS]\t',
+    '2c:f5:d3:02:ea:22\t2472\t-31\t[ESS]\t'
+].join('\n');
+
 var WPA_CLI_SCAN_NORESULTS = [
     ''
 ].join('\n');
@@ -598,6 +604,28 @@ describe('wpa_cli', function() {
                         signalLevel: -31,
                         flags: '[WPA-PSK-CCMP+TKIP][WPA2-PSK-CCMP+TKIP][ESS]',
                         ssid: 'FakeWifi2'
+                    }
+                ]);
+
+                done();
+            });
+        });
+
+        it('scan_results for hidden networks', function(done) {
+            this.OUTPUT = WPA_CLI_SCAN_RESULTS_HIDDEN;
+            wpa_cli.scan_results('wlan0', function(err, results) {
+                should(results).eql([
+                    {
+                        bssid: '2c:f5:d3:02:ea:11',
+                        flags: '[ESS]',
+                        frequency: 2472,
+                        signalLevel: -31,
+                    },
+                    {
+                        bssid: '2c:f5:d3:02:ea:22',
+                        flags: '[ESS]',
+                        frequency: 2472,
+                        signalLevel: -31
                     }
                 ]);
 

--- a/wpa_cli.js
+++ b/wpa_cli.js
@@ -192,9 +192,13 @@ function parse_scan_results(block) {
     var match;
     var results = [];
     var lines;
-    
+
+    console.log(block+'XX');
     lines = block.split('\n').map(function(item) { return item + "\n"; });
+console.log(lines);
+
     lines.forEach(function(entry){
+      console.log('entry',entry.replace('\n','')+'<');
         var parsed = {};
         if ((match = entry.match(/([A-Fa-f0-9:]{17})\t/))) {
             parsed.bssid = match[1].toLowerCase();
@@ -208,12 +212,13 @@ function parse_scan_results(block) {
             parsed.signalLevel = parseInt(match[1], 10);
         }
 
-        if ((match = entry.match(/\t(\[.+\])\t/))) {
+        if ((match = entry.match(/\t(\[.+\])\t?/))) {
             parsed.flags = match[1];
         }
 
         if ((match = entry.match(/\t([^\t]{1,32}(?=\n))/))) {
             parsed.ssid = match[1];
+            console.log('parsed.ssid',parsed.ssid);
         }
 
         if(!(Object.keys(parsed).length === 0 && parsed.constructor === Object)){
@@ -238,7 +243,7 @@ function parse_scan_results_interface(callback) {
         if (error) {
             callback(error);
         } else {
-            callback(error, parse_scan_results(stdout.trim()));
+            callback(error, parse_scan_results(stdout));
         }
     };
 }

--- a/wpa_cli.js
+++ b/wpa_cli.js
@@ -193,12 +193,8 @@ function parse_scan_results(block) {
     var results = [];
     var lines;
 
-    console.log(block+'XX');
     lines = block.split('\n').map(function(item) { return item + "\n"; });
-console.log(lines);
-
     lines.forEach(function(entry){
-      console.log('entry',entry.replace('\n','')+'<');
         var parsed = {};
         if ((match = entry.match(/([A-Fa-f0-9:]{17})\t/))) {
             parsed.bssid = match[1].toLowerCase();
@@ -218,7 +214,6 @@ console.log(lines);
 
         if ((match = entry.match(/\t([^\t]{1,32}(?=\n))/))) {
             parsed.ssid = match[1];
-            console.log('parsed.ssid',parsed.ssid);
         }
 
         if(!(Object.keys(parsed).length === 0 && parsed.constructor === Object)){


### PR DESCRIPTION
I discovered an issue with the wpa_cli parser. if the last result of a scan is an empty network, wireless-tools returns "[ESS]" as ssid, which is of course wrong.

the reason for this is, that the trim() call removes the tab and the regex fails.

I added a unit test to cover this case