### PR TITLE
fix iwconfig - extra characters

### DIFF
--- a/iwconfig.js
+++ b/iwconfig.js
@@ -111,7 +111,7 @@ function parse_status(callback) {
   return function(error, stdout, stderr) {
     if (error) callback(error);
     else callback(error,
-      stdout.trim().split('\n\n').map(parse_status_block).filter(function(i) { return !! i }));
+      stdout.trim().replace(/ {10,}/g, '').split('\n\n').map(parse_status_block).filter(function(i) { return !! i }));
   };
 }
 


### PR DESCRIPTION
fixes bug where it wouldn't parse multiple wlans: https://github.com/bakerface/wireless-tools/issues/31
