### PR TITLE
Allow ifconfig up to be performed without options

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,16 +172,17 @@ ifconfig.down('wlan0', function(err) {
 ```
 
 ## ifconfig.up(options, callback)
-The **ifconfig up** command is used to bring up an interface with the specified configuration.
+The **ifconfig up** command is used to bring up an interface with an optional specified
+configuration.
 
 ``` javascript
 var ifconfig = require('wireless-tools/ifconfig');
 
 var options = {
   interface: 'wlan0',
-  ipv4_address: '192.168.10.1',
-  ipv4_broadcast: '192.168.10.255',
-  ipv4_subnet_mask: '255.255.255.0'
+  ipv4_address(optional): '192.168.10.1',
+  ipv4_broadcast(optional): '192.168.10.255',
+  ipv4_subnet_mask(optional): '255.255.255.0'
 };
 
 ifconfig.up(options, function(err) {

--- a/ifconfig.js
+++ b/ifconfig.js
@@ -230,9 +230,9 @@ function down(interface, callback) {
  *
  * var options = {
  *   interface: 'wlan0',
- *   ipv4_address: '192.168.10.1',
- *   ipv4_broadcast: '192.168.10.255',
- *   ipv4_subnet_mask: '255.255.255.0'
+ *   ipv4_address(optional): '192.168.10.1',
+ *   ipv4_broadcast(optional): '192.168.10.255',
+ *   ipv4_subnet_mask(optional): '255.255.255.0'
  * };
  *
  * ifconfig.up(options, function(err) {
@@ -242,8 +242,8 @@ function down(interface, callback) {
  */
 function up(options, callback) {
   return this.exec('ifconfig ' + options.interface +
-    ' ' + options.ipv4_address +
-    ' netmask ' + options.ipv4_subnet_mask +
-    ' broadcast ' + options.ipv4_broadcast +
+    ((options['ipv4_address'] && (' ' + options['ipv4_address'])) || '') +
+    ((options['ipv4_subnet_mask'] && (' netmask ' + options['ipv4_subnet_mask'])) || '') +
+    ((options['ipv4_broadcast'] && (' broadcast ' + options['ipv4_broadcast'])) || '') +
     ' up', callback);
 }

--- a/ifconfig.js
+++ b/ifconfig.js
@@ -242,8 +242,8 @@ function down(interface, callback) {
  */
 function up(options, callback) {
   return this.exec('ifconfig ' + options.interface +
-    ((options['ipv4_address'] && (' ' + options['ipv4_address'])) || '') +
-    ((options['ipv4_subnet_mask'] && (' netmask ' + options['ipv4_subnet_mask'])) || '') +
-    ((options['ipv4_broadcast'] && (' broadcast ' + options['ipv4_broadcast'])) || '') +
+    ((options.ipv4_address && (' ' + options.ipv4_address)) || '') +
+    ((options.ipv4_subnet_mask && (' netmask ' + options.ipv4_subnet_mask)) || '') +
+    ((options.ipv4_broadcast && (' broadcast ' + options.ipv4_broadcast)) || '') +
     ' up', callback);
 }

--- a/test/ifconfig.js
+++ b/test/ifconfig.js
@@ -161,6 +161,23 @@ describe('ifconfig', function() {
   describe('ifconfig.up(options, callback)', function() {
     it('should bring up the interface', function(done) {
       ifconfig.exec = function(command, callback) {
+        should(command).eql('ifconfig wlan0 up');
+
+        callback(null, '', '');
+      };
+
+      var minimal_options = {
+        interface: 'wlan0'
+      };
+
+      ifconfig.up(minimal_options, function(err) {
+        should(err).not.be.ok;
+        done();
+      });
+    })
+
+    it('should bring up and configure the ip settings for the interface', function(done) {
+      ifconfig.exec = function(command, callback) {
         should(command).eql('ifconfig wlan0 192.168.10.1' +
           ' netmask 255.255.255.0 broadcast 192.168.10.255 up');
 


### PR DESCRIPTION
Occasionally, folks need `ifconfig up` to be executed without any other arguments.  This change creates tests and code to allow `ipv4_address`, `ipv4_subnet_mask`, and `ipv4_broadcast` to be optional.  If those keys are not present in the options parameter, they will not be used.